### PR TITLE
Quick fix change error to access-denied

### DIFF
--- a/lib/models/github.js
+++ b/lib/models/github.js
@@ -282,7 +282,7 @@ class Github extends GithubApi {
     this.pullRequests.getAll(query, function (err, prs) {
       if (err) {
         err = (err.code === 404)
-        ? new Warning('Cannot find open PRs for ' + shortRepo + '@' + branch,
+        ? new AccessDeniedError('Cannot find open PRs for ' + shortRepo + '@' + branch,
             { err: err })
         : new CriticalError('Failed to get PRs for ' + shortRepo + '@' + branch, { err: err })
         return cb(err)


### PR DESCRIPTION
I had check for runanbot membership and thrown AccessDeniedError if user has not access.
Now user can be member but has no access to the repo, so we should throw AccessDeniedError.
AccessDeniedError will be convetred to TaskFatalError and job will exit (https://github.com/CodeNow/pheidi/blob/master/lib/workers/github.bot.notify.js#L63).

Causing following error: https://rollbar.com/Runnable-2/pheidi/items/22/
