### PR TITLE
handle rate limit

### DIFF
--- a/lib/models/github.js
+++ b/lib/models/github.js
@@ -7,6 +7,7 @@
 const CriticalError = require('error-cat/errors/critical-error')
 const Warning = require('error-cat/errors/warning')
 const AccessDeniedError = require('models/access-denied-error')
+const RateLimitedError = require('models/rate-limited-error')
 const GithubApi = require('github')
 const crypto = require('crypto')
 const defaults = require('defaults')
@@ -281,11 +282,13 @@ class Github extends GithubApi {
     }
     this.pullRequests.getAll(query, function (err, prs) {
       if (err) {
-        err = (err.code === 404)
-        ? new Warning('Cannot find open PRs for ' + shortRepo + '@' + branch,
-            { err: err })
-        : new CriticalError('Failed to get PRs for ' + shortRepo + '@' + branch, { err: err })
-        return cb(err)
+        if (err.code === 404) {
+          return cb(new AccessDeniedError('Cannot find open PRs for ' + shortRepo + '@' + branch, { err: err }))
+        }
+        if (err.code === 403) {
+          return cb(new RateLimitedError('Cannot find open PRs for ' + shortRepo + '@' + branch, { err: err }))
+        }
+        return cb(new CriticalError('Failed to get PRs for ' + shortRepo + '@' + branch, { err: err }))
       }
       // for some reason head branch filtering is not applied.
       // TODO check if this is problem with GitHub API or nodejs lib
@@ -306,10 +309,13 @@ class Github extends GithubApi {
     }, 'acceptInvitation')
     this.user.editOrganizationMembership({ org: orgName, state: 'active' }, (err, resp) => {
       if (err) {
-        err = (err.code === 404)
-        ? new AccessDeniedError('Cannot accept invitation for ' + orgName, { err: err })
-        : new CriticalError('Failed to accept invitation for ' + orgName, { err: err })
-        return cb(err)
+        if (err.code === 404) {
+          return cb(new AccessDeniedError('Cannot accept invitation for ' + orgName, { err: err }))
+        }
+        if (err.code === 403) {
+          return cb(new RateLimitedError('Cannot accept invitation for ' + orgName, { err: err }))
+        }
+        return cb(new CriticalError('Failed to accept invitation for ' + orgName, { err: err }))
       }
       cb(null, resp)
     })

--- a/lib/models/rate-limited-error.js
+++ b/lib/models/rate-limited-error.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const BaseError = require('error-cat/errors/base-error')
+const monitor = require('monitor-dog')
+
+/**
+ * Github rate limit error
+ * @param  {[type]} message Message for the error.
+ * @param  {[type]} data    Custom data to report to rollbar.
+ */
+class RateLimitedError extends BaseError {
+  constructor (message, data) {
+    super(message, data)
+    monitor.increment('github.rate.limited')
+    this.setLevel('warn')
+  }
+}
+
+/**
+ * Monitored Error Class
+ * @module rate-limit-error:error
+ */
+module.exports = RateLimitedError

--- a/lib/workers/github.bot.notify.js
+++ b/lib/workers/github.bot.notify.js
@@ -13,6 +13,7 @@ const joi = require('joi')
 const GitHubBot = require('notifications/github.bot')
 const TaskFatalError = require('ponos').TaskFatalError
 const AccessDeniedError = require('models/access-denied-error')
+const RateLimitedError = require('models/rate-limited-error')
 const logger = require('logger')
 
 module.exports = GitHubBotNotify
@@ -62,6 +63,11 @@ function GitHubBotNotify (job) {
             if (err instanceof AccessDeniedError) {
               return cb(new TaskFatalError('github.bot.notify',
                 'Runnabot has no access to an org',
+                { err: err, job: job }))
+            }
+            if (err instanceof RateLimitedError) {
+              return cb(new TaskFatalError('github.bot.notify',
+                'Runnabot has reached rate-limit',
                 { err: err, job: job }))
             }
             return cb(err)


### PR DESCRIPTION
In case of 403 - we should throw RateLimitedError which will be converted into TaskFatalError inside the worker.
This will prevent us from cascading failure.

Also right now two methods check for access denied error: because there is a situation when runnabot is member of an org but has not access to the repo.

fix for https://rollbar.com/Runnable-2/pheidi/items/23/ and https://rollbar.com/Runnable-2/pheidi/items/23/
- [x] @thejsj
