### PR TITLE
Remove call to github to fetch user

### DIFF
--- a/lib/workers/instance.deployed.js
+++ b/lib/workers/instance.deployed.js
@@ -10,6 +10,7 @@ const Promise = require('bluebird')
 
 const ObjectID = require('mongodb').ObjectID
 const joi = require('joi')
+const keypather = require('keypather')()
 const mongodbHelper = require('mongo-helper')
 
 const GitHubDeploy = require('notifications/github.deploy')
@@ -68,6 +69,13 @@ function InstanceDeployed (job) {
                 'instance.deployed',
                 'Instance not found',
                 { report: false, job: job }
+              )
+            }
+            if (!keypather.get(instance, 'owner.username')) {
+              throw new TaskFatalError(
+                'instance.deployed',
+                'Instance owner username was not found',
+                { job: job }
               )
             }
             if (!cv) {

--- a/test/unit/workers/instance.deployed.js
+++ b/test/unit/workers/instance.deployed.js
@@ -216,6 +216,17 @@ describe('Instance Deployed Worker', function () {
           })
         })
 
+        it('should reject when instance had no ownerUsername found with TaskFatalError', function (done) {
+          Mongo.prototype.findOneInstanceAsync.resolves({})
+
+          Worker(testData).asCallback(function (err) {
+            assert.isDefined(err)
+            assert.instanceOf(err, TaskFatalError)
+            assert.match(err.message, /instance owner username was not found/i)
+            done()
+          })
+        })
+
         it('should reject when context version not found with TaskFatalError', function (done) {
           Mongo.prototype.findOneContextVersionAsync.resolves(null)
 
@@ -276,7 +287,9 @@ describe('Instance Deployed Worker', function () {
         Worker(testData).asCallback(function (err) {
           assert.isNull(err)
           sinon.assert.calledOnce(Mongo.prototype.findOneInstanceAsync)
-          sinon.assert.calledWith(Mongo.prototype.findOneInstanceAsync, { _id: new ObjectID(testInstanceId) })
+          sinon.assert.calledWith(Mongo.prototype.findOneInstanceAsync, {
+            _id: new ObjectID(testInstanceId)
+          })
           done()
         })
       })


### PR DESCRIPTION
@Nathan219 changed create instance route and now we can rely that instance always has owner.username at the moment we receive first event.

If we don't have that data at any moment we will get error in rollbar and we will investigate and find the root cause
