### PR TITLE
fix md formatting

### DIFF
--- a/lib/notifications/github.bot.js
+++ b/lib/notifications/github.bot.js
@@ -253,7 +253,7 @@ class GitHubBot {
         const link = this._createServerLink(instance, instanceUrl)
         return ' - ' + link
       })
-      message += linksList.join('')
+      message += linksList.join('\n')
     }
     return message
   }

--- a/test/unit/notifications/github.bot.js
+++ b/test/unit/notifications/github.bot.js
@@ -727,7 +727,7 @@ describe('GitHubBot', function () {
         }
       ]
       const md = githubBot._renderIsolatedInstance(insts)
-      let expectedMd = '\n\nIsolated instances:\n - [inst-1](https://web.runnable.dev/codenow/inst-1?ref=pr)'
+      let expectedMd = '\n\nIsolated instances:\n - [inst-1](https://web.runnable.dev/codenow/inst-1?ref=pr)\n'
       expectedMd += ' - [inst-2](https://web.runnable.dev/codenow/inst-2?ref=pr)'
       assert.equal(md, expectedMd)
       done()


### PR DESCRIPTION
Add `\n` when rendering list of instances
