### PR TITLE
Lock mongo driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "keypather": "^2.0.0",
     "loadenv": "^2.1.0",
     "lru-cache": "^4.0.1",
-    "mongodb": "^2.1.16",
+    "mongodb": "2.1.17",
     "monitor-dog": "^1.5.0",
     "ponos": "^4.2.1",
     "runnable-hostname": "git+ssh://git@github.com:CodeNow/runnable-hostname#v1.0.4",


### PR DESCRIPTION
Mongo driver was updated automatically to 2.2.2 which doesn't work.
So we just lock down dependency version
