### PR TITLE
Disable instance.deployed queue for now

### DIFF
--- a/lib/worker-server.js
+++ b/lib/worker-server.js
@@ -29,7 +29,7 @@ module.exports = new ponos.Server({
     'container.life-cycle.died': require('./workers/container.life-cycle.died'),
     'container.life-cycle.started': require('./workers/container.life-cycle.started'),
     'instance.deleted': require('./workers/instance.deleted'),
-    'instance.deployed': require('./workers/instance.deployed'),
+    // 'instance.deployed': require('./workers/instance.deployed'),
     'instance.updated': require('./workers/instance.updated')
   }
 })


### PR DESCRIPTION
This queue only used for slack messages.
runnabot is still up since it's using instance.updated event
