### PR TITLE
Do not send messages for test instances

### DIFF
--- a/lib/workers/instance.deleted.js
+++ b/lib/workers/instance.deleted.js
@@ -51,10 +51,14 @@ module.exports.task = (job) => {
   })
   return Promise
     .try(() => {
+      // do nothing for test instance
+      if (job.instance.isTesting) {
+        return
+      }
       // only whitelisted orgs have runnabot github notifications
       if (process.env.PR_BOT_WHITELIST.includes(job.instance.owner.github)) {
         const cv = keypather.get(job, 'instance.contextVersions[0]') || {}
-        const acv = cv.appCodeVersions.find(function (a) {
+        const acv = cv.appCodeVersions.find((a) => {
           return !a.additionalRepo
         })
         // if acv doesn't exist it's non-repo instance

--- a/lib/workers/instance.deployed.js
+++ b/lib/workers/instance.deployed.js
@@ -58,6 +58,9 @@ module.exports.task = (job) => {
         if (!cv) {
           throw new WorkerStopError('ContextVersion not found', { level: 'info' })
         }
+        if (instance.isTesting) {
+          throw new WorkerStopError('No notifications for testing instance', { level: 'info' })
+        }
         const tasks = {
           // instanceCreator is the user who created an instance
           instanceCreator: mongoClient.findOneUserAsync({ 'accounts.github.id': instance.createdBy.github }),

--- a/lib/workers/instance.updated.js
+++ b/lib/workers/instance.updated.js
@@ -56,7 +56,7 @@ module.exports.task = (job) => {
       if (process.env.PR_BOT_WHITELIST.includes(job.instance.owner.github)) {
         const container = keypather.get(job, 'instance.containers[0]') || {}
         const cv = keypather.get(job, 'instance.contextVersions[0]') || {}
-        const acv = cv.appCodeVersions.find(function (a) {
+        const acv = cv.appCodeVersions.find((a) => {
           return !a.additionalRepo
         })
         // if acv doesn't exist it's non-repo instance

--- a/lib/workers/instance.updated.js
+++ b/lib/workers/instance.updated.js
@@ -48,6 +48,10 @@ module.exports.task = (job) => {
   })
   return Promise
     .try(() => {
+      // do nothing for test instance
+      if (job.instance.isTesting) {
+        return
+      }
       // only whitelisted orgs will receive runnabot github notifications for now
       if (process.env.PR_BOT_WHITELIST.includes(job.instance.owner.github)) {
         const container = keypather.get(job, 'instance.containers[0]') || {}

--- a/test/unit/workers/instance.deleted.js
+++ b/test/unit/workers/instance.deleted.js
@@ -16,7 +16,7 @@ const WorkerStopError = require('error-cat/errors/worker-stop-error')
 const GitHubBot = require('notifications/github.bot')
 const Worker = require('workers/instance.deleted').task
 
-describe('Instance Updated Worker', function () {
+describe('Instance Deleted Worker', function () {
   describe('worker', function () {
     describe('regular flow', function () {
       beforeEach(function (done) {
@@ -29,6 +29,31 @@ describe('Instance Updated Worker', function () {
         GitHubBot.prototype.deleteBranchNotificationsAsync.restore()
         GitHubBot.prototype.deleteAllNotificationsAsync.restore()
         done()
+      })
+
+      it('should do nothing if testing instance', function (done) {
+        const instance = {
+          isTesting: true,
+          owner: {
+            github: 2828361
+          },
+          contextVersions: [
+            {
+              appCodeVersions: [
+                {
+                  repo: 'CodeNow/api',
+                  branch: 'feature1'
+                }
+              ]
+            }
+          ]
+        }
+        Worker({ instance: instance }).asCallback(function (err) {
+          assert.isNull(err)
+          sinon.assert.notCalled(GitHubBot.prototype.deleteBranchNotificationsAsync)
+          sinon.assert.notCalled(GitHubBot.prototype.deleteAllNotificationsAsync)
+          done()
+        })
       })
 
       it('should do nothing if org was not whitelisted', function (done) {

--- a/test/unit/workers/instance.deployed.js
+++ b/test/unit/workers/instance.deployed.js
@@ -161,6 +161,22 @@ describe('Instance Deployed Worker', function () {
           })
         })
 
+        it('should reject when instance isTesting with WorkerStopError', function (done) {
+          Mongo.prototype.findOneInstanceAsync.resolves({
+            isTesting: true,
+            owner: {
+              username: 'runnable'
+            }
+          })
+
+          Worker(testData).asCallback(function (err) {
+            assert.isDefined(err)
+            assert.instanceOf(err, WorkerStopError)
+            assert.match(err.message, /no notifications for testing instance/i)
+            done()
+          })
+        })
+
         it('should reject when instance had no ownerUsername found with WorkerStopError', function (done) {
           Mongo.prototype.findOneInstanceAsync.resolves({})
 

--- a/test/unit/workers/instance.updated.js
+++ b/test/unit/workers/instance.updated.js
@@ -121,6 +121,33 @@ describe('Instance Updated Worker', function () {
         })
       })
 
+      it('should do nothing if testing instance', function (done) {
+        const instance = {
+          owner: {
+            github: 2828361
+          },
+          isTesting: true,
+          contextVersions: [
+            {
+              appCodeVersions: [
+                {
+                  repo: 'CodeNow/api',
+                  branch: 'feature1'
+                }
+              ],
+              build: {
+                failed: true
+              }
+            }
+          ]
+        }
+        Worker({ instance: instance }).asCallback(function (err) {
+          assert.isNull(err)
+          sinon.assert.notCalled(rabbitmq.publishGitHubBotNotify)
+          done()
+        })
+      })
+
       it('should do nothing if org was not whitelisted', function (done) {
         const instance = {
           owner: {


### PR DESCRIPTION
Do not send GitHub runnabot message or slack message for test instances.
Test instances have only GitHub PR statuses.
